### PR TITLE
mirage-solo5: Add missing solo5-kernel-ukvm dependency

### DIFF
--- a/packages/mirage-solo5/mirage-solo5.0.0.1/opam
+++ b/packages/mirage-solo5/mirage-solo5.0.0.1/opam
@@ -25,5 +25,6 @@ depends: [
   "conf-pkg-config"
   "mirage-profile" {>= "0.3"}
   "mirage-xen-ocaml"
+  "solo5-kernel-ukvm"
 ]
 available: [ ocaml-version >= "4.01.0" & os = "linux" ]


### PR DESCRIPTION
Part of djwillia/solo5#10.
